### PR TITLE
fix: update query message to be compatible with trapi 1.1

### DIFF
--- a/__test__/trapi_query_builder.test.js
+++ b/__test__/trapi_query_builder.test.js
@@ -25,9 +25,9 @@ describe("test trapi query builder class", () => {
             expect(res).toHaveProperty('url', 'https://google.com/query');
             expect(res).toHaveProperty('timeout', 3000);
             expect(res.data.message.query_graph.nodes.n0.ids).toEqual(['123', '456']);
-            expect(res.data.message.query_graph.nodes.n0.categories).toEqual('biolink:Pathway');
-            expect(res.data.message.query_graph.nodes.n1.categories).toEqual('biolink:Gene');
-            expect(res.data.message.query_graph.edges.e01.predicates).toEqual('biolink:related_to');
+            expect(res.data.message.query_graph.nodes.n0.categories).toContain('biolink:Pathway');
+            expect(res.data.message.query_graph.nodes.n1.categories).toContain('biolink:Gene');
+            expect(res.data.message.query_graph.edges.e01.predicates).toContain('biolink:related_to');
         })
     })
 })

--- a/src/builder/trapi_query_builder.js
+++ b/src/builder/trapi_query_builder.js
@@ -47,18 +47,18 @@ module.exports = class TRAPIQueryBuilder {
                 "query_graph": {
                     "nodes": {
                         "n0": {
-                            "ids": input,
-                            "categories": "biolink:" + edge.association.input_type
+                            "ids": Array.isArray(input) ? input : [input],
+                            "categories": ["biolink:" + edge.association.input_type]
                         },
                         "n1": {
-                            "categories": "biolink:" + edge.association.output_type
+                            "categories": ["biolink:" + edge.association.output_type]
                         }
                     },
                     "edges": {
                         "e01": {
                             "subject": "n0",
                             "object": "n1",
-                            "predicates": "biolink:" + edge.association.predicate
+                            "predicates": ["biolink:" + edge.association.predicate]
                         }
                     }
                 }


### PR DESCRIPTION
related to issue https://github.com/biothings/call-apis.js/issues/18

pluralization of key names and values