### PR TITLE
fix: :bug: ignore undefined items in array

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -138,7 +138,9 @@ module.exports = class APIQueryDispathcer {
             res = await biomedical_resolver.resolve(grpedIDs);
         }
         result.map(item => {
-            item.$output.obj = res[item.$output.original];
+            if (item && item !== undefined) {
+                item.$output.obj = res[item.$output.original];
+            }
         });
         return result;
     }


### PR DESCRIPTION
Tests can sometimes generate undefined results, ignore such results while annotating edges.