### PR TITLE
Fix currently failing test by removing unused mock

### DIFF
--- a/__test__/query.test.js
+++ b/__test__/query.test.js
@@ -29,7 +29,7 @@ jest.mock('../src/query_queue', () => {
     });
 });
 
-jest.mock('axios');
+// jest.mock('axios');
 
 describe("Test query class", () => {
     describe("Test _merge function", () => {


### PR DESCRIPTION
`jest.mock('axios');` causes test `check if annotated ids are correctly mapped` to fail, and is otherwise unused in the test suite.