### PR TITLE
Templating revision

### DIFF
--- a/__test__/data/multi_input_edge.json
+++ b/__test__/data/multi_input_edge.json
@@ -1,12 +1,21 @@
 {
+  "useTemplating": true,
   "input": {
     "id": "MONDO:0005252",
     "fields": [
       "subject",
       "association"
-    ],
-    "specialpath": "/querytest"
+    ]
   },
+  "templateInputs": {
+    "specialpath": "/querytest",
+    "id": "MONDO:0005252",
+    "fields": [
+      "subject",
+      "association"
+    ]
+  },
+  "queryInputs": ["abc", "def"],
   "query_operation": {
     "path_params": [
       "path"

--- a/__test__/trapi_query_builder.test.js
+++ b/__test__/trapi_query_builder.test.js
@@ -23,75 +23,11 @@ describe("test trapi query builder class", () => {
             const builder = new qb(edge);
             const res = builder.getConfig();
             expect(res).toHaveProperty('url', 'https://google.com/query');
-            expect(res).toHaveProperty('timeout', 3000);
+            expect(res).toHaveProperty('timeout', 10000);
             expect(res.data.message.query_graph.nodes.n0.ids).toEqual(['123', '456']);
             expect(res.data.message.query_graph.nodes.n0.categories).toContain('biolink:Pathway');
             expect(res.data.message.query_graph.nodes.n1.categories).toContain('biolink:Gene');
             expect(res.data.message.query_graph.edges.e01.predicates).toContain('biolink:related_to');
-        })
-    })
-
-    describe("test nunjucks support", () => {
-        test("if _getUrl nunjucks templates are filled", () => {
-            const edge = {
-                query_operation: {
-                    server: "https://google.com/",
-                    path: "{path}",
-                    path_params: ["path"],
-                    params: {path: "{{ specialpath }}"}
-                },
-                association: {
-                    input_type: "Pathway",
-                    output_type: "Gene",
-                    predicate: "related_to",
-                },
-                input: {specialpath: "/querytest"},
-            };
-            const builder = new qb(edge);
-            const res = builder._getUrl(edge, edge.input);
-            expect(res).toEqual("https://google.com/querytest");
-        })
-
-        test("if _getBody nunjucks templates are filled", () => {
-            const edge = {
-                query_operation: {
-                    server: "https://google.com/",
-                    path: "/query"
-                },
-                association: {
-                    input_type: ['Pathway', 'SomethingElse', '{{ SpecialInput }}'],
-                    output_type: 'Gene',
-                    predicate: 'related_to'
-                },
-                input: {
-                    ids: ['123', '456'],
-                    SpecialInput: "TestSuccess"
-                }
-            }
-            const builder = new qb(edge);
-            const res = builder._getRequestBody(edge, edge.input);
-            expect(res).toEqual({
-                message: {
-                    query_graph: {
-                    nodes: {
-                        n0: {
-                        ids: ['123', '456'],
-                        categories: ['biolink:Pathway', 'biolink:SomethingElse', 'biolink:TestSuccess'],
-                        },
-                        n1: {
-                        categories: ['biolink:Gene'],
-                        },
-                    },
-                    edges: {
-                        e01: {
-                        subject: "n0",
-                        object: "n1",
-                        predicates: ['biolink:related_to'],
-                        },
-                    },
-                    },
-                },
-            });
         })
     })
 })

--- a/src/builder/builde_factory.js
+++ b/src/builder/builde_factory.js
@@ -1,5 +1,6 @@
 const default_builder = require("./query_builder");
 const trapi_builder = require("./trapi_query_builder");
+const template_builder = require("./template_query_builder")
 const debug = require("debug")("bte:call-apis:query");
 
 
@@ -7,6 +8,9 @@ const builder_factory = (edge) => {
     if ('tags' in edge && edge.tags.includes('bte-trapi')) {
         debug(`using trapi builder now`)
         return new trapi_builder(edge);
+    } else if (edge.query_operation.useTemplating) {
+        debug("using template builder");
+        return new template_builder(edge);
     }
     debug('using default builder')
     return new default_builder(edge);

--- a/src/builder/nunjucks_config.js
+++ b/src/builder/nunjucks_config.js
@@ -25,6 +25,13 @@ mappableStringTemplateFuncs.rmPrefix = (input, delim) => {
 mappableStringTemplateFuncs.replPrefix = (input, prefix, delim) => {
   return mappableStringTemplateFuncs.addPrefix(mappableStringTemplateFuncs.rmPrefix(input, delim), prefix, delim);
 };
+mappableStringTemplateFuncs.wrap = (input, start, end) => {
+  if (typeof start === "undefined") {
+    return input;
+  }
+  end = end || start;
+  return String(start) + String(input) + String(end);
+};
 
 arrayOnlyTemplateFuncs.joinSafe = (input, delim) => {
   return Array.isArray(input) ? input.join(delim) : input;
@@ -48,6 +55,6 @@ module.exports = env => {
     env.addFilter(key, mapIfNeeded(mappableStringTemplateFuncs[key]));
   });
   Object.keys(arrayOnlyTemplateFuncs).forEach(key => {
-    env.addFilter(key, arrayOnlyTemplateFuncs[key])
-  })
+    env.addFilter(key, arrayOnlyTemplateFuncs[key]);
+  });
 };

--- a/src/builder/nunjucks_config.js
+++ b/src/builder/nunjucks_config.js
@@ -4,34 +4,39 @@
  * Functions need only work on single-string inputs -- they are automatically
  * mapped if being applied to an array of inputs.
  */
-const templateFuncs = {}; // storage for all funcs, when defining new add here
+const mappableStringTemplateFuncs = {}; // defined on str, can be mapped to array
+const arrayOnlyTemplateFuncs = {}; // defined on array
 
-templateFuncs.substr = (input, begin, end) => {
+mappableStringTemplateFuncs.substr = (input, begin, end) => {
   begin = begin || 0;
   end = end || input.length;
   return input.slice(begin, end);
 };
-templateFuncs.addPrefix = (input, prefix, delim) => {
+mappableStringTemplateFuncs.addPrefix = (input, prefix, delim) => {
   prefix = prefix || "";
   delim = delim || ":";
   return prefix.length !== 0 ? prefix + delim + input : input;
 };
-templateFuncs.rmPrefix = (input, delim) => {
+mappableStringTemplateFuncs.rmPrefix = (input, delim) => {
   delim = delim || ":";
   split = input.split(delim);
   return split.length < 2 ? input : split[1];
 };
-templateFuncs.replPrefix = (input, prefix, delim) => {
-  return templateFuncs.addPrefix(templateFuncs.rmPrefix(input, delim), prefix, delim);
+mappableStringTemplateFuncs.replPrefix = (input, prefix, delim) => {
+  return mappableStringTemplateFuncs.addPrefix(mappableStringTemplateFuncs.rmPrefix(input, delim), prefix, delim);
 };
 
-const mapIfNeeded = (func) => {
+arrayOnlyTemplateFuncs.joinSafe = (input, delim) => {
+  return Array.isArray(input) ? input.join(delim) : input;
+};
+
+const mapIfNeeded = func => {
   return (...args) => {
-    const input = args.shift()
+    const input = args.shift();
     if (typeof input === "undefined") {
       return undefined;
     } else if (Array.isArray(input)) {
-      return input.map((item) => func(item, ...args));
+      return input.map(item => func(item, ...args));
     } else {
       return func(input, ...args);
     }
@@ -39,7 +44,10 @@ const mapIfNeeded = (func) => {
 };
 
 module.exports = env => {
-  Object.keys(templateFuncs).forEach(key => {
-    env.addFilter(key, mapIfNeeded(templateFuncs[key]));
+  Object.keys(mappableStringTemplateFuncs).forEach(key => {
+    env.addFilter(key, mapIfNeeded(mappableStringTemplateFuncs[key]));
   });
+  Object.keys(arrayOnlyTemplateFuncs).forEach(key => {
+    env.addFilter(key, arrayOnlyTemplateFuncs[key])
+  })
 };

--- a/src/builder/query_builder.js
+++ b/src/builder/query_builder.js
@@ -80,45 +80,45 @@ module.exports = class QueryBuilder {
             }
         }
 
-        /**
-        * Construct the request config for Axios reqeust.
-        */
-        constructAxiosRequestConfig() {
-            const input = this._getInput(this.edge);
-            const config = {
-                url: this._getUrl(this.edge, input),
-                params: this._getParams(this.edge, input),
-                data: this._getRequestBody(this.edge, input),
-                method: this.edge.query_operation.method,
-                timeout: 50000,
-            };
-            this.config = config;
-            return config;
-        }
+    /**
+    * Construct the request config for Axios reqeust.
+    */
+    constructAxiosRequestConfig() {
+        const input = this._getInput(this.edge);
+        const config = {
+            url: this._getUrl(this.edge, input),
+            params: this._getParams(this.edge, input),
+            data: this._getRequestBody(this.edge, input),
+            method: this.edge.query_operation.method,
+            timeout: 50000,
+        };
+        this.config = config;
+        return config;
+    }
 
-        needPagination(apiResponse) {
-            if (this.edge.query_operation.method === "get" && this.edge.tags.includes("biothings")) {
-                if (apiResponse.total > this.start + apiResponse.hits.length) {
-                    this.hasNext = true;
-                    return true;
-                }
+    needPagination(apiResponse) {
+        if (this.edge.query_operation.method === "get" && this.edge.tags.includes("biothings")) {
+            if (apiResponse.total > this.start + apiResponse.hits.length) {
+                this.hasNext = true;
+                return true;
             }
-            this.hasNext = false;
-            return false;
         }
+        this.hasNext = false;
+        return false;
+    }
 
-        getNext() {
-            this.start += 1000;
-            const config = this.constructAxiosRequestConfig(this.edge);
-            config.params.from = this.start;
-            this.config = config;
-            return config;
-        }
+    getNext() {
+        this.start += 1000;
+        const config = this.constructAxiosRequestConfig(this.edge);
+        config.params.from = this.start;
+        this.config = config;
+        return config;
+    }
 
-        getConfig() {
-            if (this.hasNext === false) {
-                return this.constructAxiosRequestConfig(this.edge);
-            }
-            return this.getNext();
+    getConfig() {
+        if (this.hasNext === false) {
+            return this.constructAxiosRequestConfig(this.edge);
         }
-    };
+        return this.getNext();
+    }
+};

--- a/src/builder/query_builder.js
+++ b/src/builder/query_builder.js
@@ -1,124 +1,124 @@
 /**
- * Build API queries serving as input for Axios library based on BTE Edge info
- */
+* Build API queries serving as input for Axios library based on BTE Edge info
+*/
 const nunjucks = require("nunjucks");
 const nunjucksConfig = require("./nunjucks_config");
 const env = nunjucks.configure({ autoescape: false });
 nunjucksConfig(env);
 module.exports = class QueryBuilder {
-  /**
-   * Constructor for Query Builder
-   * @param {object} edge - BTE Edge object with input field provided
-   */
-  constructor(edge) {
-    this.start = 0;
-    this.hasNext = false;
-    this.edge = edge;
-  }
-
-  getUrl() {
-    return this.edge.query_operation.server + this.edge.query_operation.path;
-  }
-
-  _getUrl(edge, input) {
-    let server = edge.query_operation.server;
-    if (server.endsWith("/")) {
-      server = server.substring(0, server.length - 1);
+    /**
+    * Constructor for Query Builder
+    * @param {object} edge - BTE Edge object with input field provided
+    */
+    constructor(edge) {
+        this.start = 0;
+        this.hasNext = false;
+        this.edge = edge;
     }
-    let path = edge.query_operation.path;
-    if (Array.isArray(edge.query_operation.path_params)) {
-        edge.query_operation.path_params.map(param => {
-          const val = edge.query_operation.params[param];
-          path = path.replace("{" + param + "}", val).replace("{inputs[0]}", input);
+
+    getUrl() {
+        return this.edge.query_operation.server + this.edge.query_operation.path;
+    }
+
+    _getUrl(edge, input) {
+        let server = edge.query_operation.server;
+        if (server.endsWith("/")) {
+            server = server.substring(0, server.length - 1);
+        }
+        let path = edge.query_operation.path;
+        if (Array.isArray(edge.query_operation.path_params)) {
+            edge.query_operation.path_params.map(param => {
+                const val = edge.query_operation.params[param];
+                path = path.replace("{" + param + "}", val).replace("{inputs[0]}", input);
+            });
+        }
+        return server + path;
+    }
+
+    /**
+    * Construct input based on method and inputSeparator
+    */
+    _getInput(edge) {
+        if (edge.query_operation.supportBatch === true) {
+            if (Array.isArray(edge.input)) {
+                return edge.input.join(edge.query_operation.inputSeparator);
+            }
+        }
+        return edge.input;
+    }
+
+    /**
+    * Construct parameters for API calls
+    */
+    _getParams(edge, input) {
+        const params = {};
+        Object.keys(edge.query_operation.params).map(param => {
+            if (Array.isArray(edge.query_operation.path_params) && edge.query_operation.path_params.includes(param)) {
+                return;
+            }
+            if (typeof edge.query_operation.params[param] === "string") {
+                params[param] = edge.query_operation.params[param].replace("{inputs[0]}", input);
+            } else {
+                params[param] = edge.query_operation.params[param];
+            }
         });
+        return params;
     }
-    return server + path;
-  }
 
-  /**
-   * Construct input based on method and inputSeparator
-   */
-  _getInput(edge) {
-    if (edge.query_operation.supportBatch === true) {
-      if (Array.isArray(edge.input)) {
-        return edge.input.join(edge.query_operation.inputSeparator);
-      }
-    }
-    return edge.input;
-  }
+    /**
+    * Construct request body for API calls
+    */
+    _getRequestBody(edge, input) {
+        if (edge.query_operation.request_body !== undefined && "body" in edge.query_operation.request_body) {
+            let body = edge.query_operation.request_body.body;
+            let data;
+            data = Object.keys(body).reduce(
+                (accumulator, key) => accumulator + key + "=" + body[key].toString().replace("{inputs[0]}", input) + "&",
+                "",
+                );
+                return data.substring(0, data.length - 1);
+            }
+        }
 
-  /**
-   * Construct parameters for API calls
-   */
-  _getParams(edge, input) {
-    const params = {};
-    Object.keys(edge.query_operation.params).map(param => {
-      if (Array.isArray(edge.query_operation.path_params) && edge.query_operation.path_params.includes(param)) {
-        return;
-      }
-      if (typeof edge.query_operation.params[param] === "string") {
-          params[param] = edge.query_operation.params[param].replace("{inputs[0]}", input);
-      } else {
-        params[param] = edge.query_operation.params[param];
-      }
-    });
-    return params;
-  }
+        /**
+        * Construct the request config for Axios reqeust.
+        */
+        constructAxiosRequestConfig() {
+            const input = this._getInput(this.edge);
+            const config = {
+                url: this._getUrl(this.edge, input),
+                params: this._getParams(this.edge, input),
+                data: this._getRequestBody(this.edge, input),
+                method: this.edge.query_operation.method,
+                timeout: 50000,
+            };
+            this.config = config;
+            return config;
+        }
 
-  /**
-   * Construct request body for API calls
-   */
-  _getRequestBody(edge, input) {
-    if (edge.query_operation.request_body !== undefined && "body" in edge.query_operation.request_body) {
-      let body = edge.query_operation.request_body.body;
-      let data;
-        data = Object.keys(body).reduce(
-          (accumulator, key) => accumulator + key + "=" + body[key].toString().replace("{inputs[0]}", input) + "&",
-          "",
-        );
-      return data.substring(0, data.length - 1);
-    }
-  }
+        needPagination(apiResponse) {
+            if (this.edge.query_operation.method === "get" && this.edge.tags.includes("biothings")) {
+                if (apiResponse.total > this.start + apiResponse.hits.length) {
+                    this.hasNext = true;
+                    return true;
+                }
+            }
+            this.hasNext = false;
+            return false;
+        }
 
-  /**
-   * Construct the request config for Axios reqeust.
-   */
-  constructAxiosRequestConfig() {
-    const input = this._getInput(this.edge);
-    const config = {
-      url: this._getUrl(this.edge, input),
-      params: this._getParams(this.edge, input),
-      data: this._getRequestBody(this.edge, input),
-      method: this.edge.query_operation.method,
-      timeout: 50000,
+        getNext() {
+            this.start += 1000;
+            const config = this.constructAxiosRequestConfig(this.edge);
+            config.params.from = this.start;
+            this.config = config;
+            return config;
+        }
+
+        getConfig() {
+            if (this.hasNext === false) {
+                return this.constructAxiosRequestConfig(this.edge);
+            }
+            return this.getNext();
+        }
     };
-    this.config = config;
-    return config;
-  }
-
-  needPagination(apiResponse) {
-    if (this.edge.query_operation.method === "get" && this.edge.tags.includes("biothings")) {
-      if (apiResponse.total > this.start + apiResponse.hits.length) {
-        this.hasNext = true;
-        return true;
-      }
-    }
-    this.hasNext = false;
-    return false;
-  }
-
-  getNext() {
-    this.start += 1000;
-    const config = this.constructAxiosRequestConfig(this.edge);
-    config.params.from = this.start;
-    this.config = config;
-    return config;
-  }
-
-  getConfig() {
-    if (this.hasNext === false) {
-      return this.constructAxiosRequestConfig(this.edge);
-    }
-    return this.getNext();
-  }
-};

--- a/src/builder/query_builder.js
+++ b/src/builder/query_builder.js
@@ -27,17 +27,10 @@ module.exports = class QueryBuilder {
     }
     let path = edge.query_operation.path;
     if (Array.isArray(edge.query_operation.path_params)) {
-      if (typeof input === "object" && !Array.isArray(input)) {
-        edge.query_operation.path_params.map(param => {
-          const val = edge.query_operation.params[param];
-          path = nunjucks.renderString(path.replace("{" + param + "}", val), input);
-        });
-      } else {
         edge.query_operation.path_params.map(param => {
           const val = edge.query_operation.params[param];
           path = path.replace("{" + param + "}", val).replace("{inputs[0]}", input);
         });
-      }
     }
     return server + path;
   }
@@ -64,11 +57,7 @@ module.exports = class QueryBuilder {
         return;
       }
       if (typeof edge.query_operation.params[param] === "string") {
-        if (typeof input === "object" && !Array.isArray(input)) {
-          params[param] = nunjucks.renderString(edge.query_operation.params[param], input);
-        } else {
           params[param] = edge.query_operation.params[param].replace("{inputs[0]}", input);
-        }
       } else {
         params[param] = edge.query_operation.params[param];
       }
@@ -83,16 +72,10 @@ module.exports = class QueryBuilder {
     if (edge.query_operation.request_body !== undefined && "body" in edge.query_operation.request_body) {
       let body = edge.query_operation.request_body.body;
       let data;
-      if (typeof input === "object" && !Array.isArray(input)) {
-        data = Object.keys(body).reduce((accumulator, key) => {
-          return accumulator + key + "=" + nunjucks.renderString(body[key].toString(), input) + "&";
-        }, "");
-      } else {
         data = Object.keys(body).reduce(
           (accumulator, key) => accumulator + key + "=" + body[key].toString().replace("{inputs[0]}", input) + "&",
           "",
         );
-      }
       return data.substring(0, data.length - 1);
     }
   }

--- a/src/builder/template_query_builder.js
+++ b/src/builder/template_query_builder.js
@@ -29,7 +29,6 @@ module.exports = class TemplateQueryBuilder {
     if (Array.isArray(edge.query_operation.path_params)) {
       edge.query_operation.path_params.map(param => {
         const val = edge.query_operation.params[param];
-        // not sure why we're overriding this each time
         path = nunjucks.renderString(path.replace("{" + param + "}", val), input);
       });
     }

--- a/src/builder/template_query_builder.js
+++ b/src/builder/template_query_builder.js
@@ -68,14 +68,13 @@ module.exports = class TemplateQueryBuilder {
     if (edge.query_operation.request_body !== undefined && "body" in edge.query_operation.request_body) {
       let body = edge.query_operation.request_body.body;
       let data;
-      // TODO figure out how this might need to be copied/renamed
-      if (edge.query_operation.body_type === "string") {
+      if (edge.query_operation.requestBodyType === "object") { // TODO figure out way to signal further parse into object
+        data = Object.fromEntries(Object.entries(body).map(([key, val]) => [key, nunjucks.renderString(val, input)]));
+      } else {
         data = Object.keys(body).reduce((accumulator, key) => {
           return accumulator + key + "=" + nunjucks.renderString(body[key].toString(), input) + "&";
         }, "");
         data = data.substring(0, data.length - 1);
-      } else {
-        data = Object.fromEntries(Object.entries(body).map(([key, val]) => [key, nunjucks.renderString(val, input)]));
       }
       return data;
     }

--- a/src/builder/template_query_builder.js
+++ b/src/builder/template_query_builder.js
@@ -68,8 +68,8 @@ module.exports = class TemplateQueryBuilder {
     if (edge.query_operation.request_body !== undefined && "body" in edge.query_operation.request_body) {
       let body = edge.query_operation.request_body.body;
       let data;
-      if (edge.query_operation.requestBodyType === "object") { // TODO figure out way to signal further parse into object
-        data = Object.fromEntries(Object.entries(body).map(([key, val]) => [key, nunjucks.renderString(val, input)]));
+      if (edge.query_operation.requestBodyType === "object") {
+        data = JSON.parse(nunjucks.renderString(body, input));
       } else {
         data = Object.keys(body).reduce((accumulator, key) => {
           return accumulator + key + "=" + nunjucks.renderString(body[key].toString(), input) + "&";

--- a/src/builder/trapi_query_builder.js
+++ b/src/builder/trapi_query_builder.js
@@ -46,7 +46,7 @@ module.exports = class TRAPIQueryBuilder {
      * Construct TRAPI request body
      */
     _getRequestBody(edge, input) {
-        qg = {
+        const qg = {
             "message": {
                 "query_graph": {
                     "nodes": {

--- a/src/builder/trapi_query_builder.js
+++ b/src/builder/trapi_query_builder.js
@@ -27,17 +27,10 @@ module.exports = class TRAPIQueryBuilder {
         };
         let path = edge.query_operation.path;
         if (Array.isArray(edge.query_operation.path_params)) {
-            if (typeof input === "object" && !Array.isArray(input)) {
-              edge.query_operation.path_params.map(param => {
-                const val = edge.query_operation.params[param];
-                path = nunjucks.renderString(path.replace("{" + param + "}", val), input);
-              });
-            } else {
               edge.query_operation.path_params.map(param => {
                 const val = edge.query_operation.params[param];
                 path = path.replace("{" + param + "}", val).replace("{inputs[0]}", input);
               });
-            }
         }
         return server + path;
     }
@@ -54,36 +47,6 @@ module.exports = class TRAPIQueryBuilder {
      */
     _getRequestBody(edge, input) {
         let qg;
-        if (typeof input === "object" && !Array.isArray(input)) {
-            qg = {
-                "message": {
-                    "query_graph": {
-                        "nodes": {
-                            "n0": {
-                                "ids": Array.isArray(input.ids) ? input.ids.map(id => nunjucks.renderString(id, input)) : [nunjucks.renderString(input.ids, input)],
-                                "categories": Array.isArray(edge.association.input_type)
-                                    ? edge.association.input_type.map(type => nunjucks.renderString("biolink:" + type, input))
-                                    : ["biolink:" + edge.association.input_type]
-                            },
-                            "n1": {
-                                "categories": Array.isArray(edge.association.output_type)
-                                    ? edge.association.output_type.map(type => nunjucks.renderString("biolink:" + type, input))
-                                    : ["biolink:" + edge.association.output_type]
-                            }
-                        },
-                        "edges": {
-                            "e01": {
-                                "subject": "n0",
-                                "object": "n1",
-                                "predicates": Array.isArray(edge.association.predicate)
-                                    ? edge.association.predicate.map(pred => nunjucks.renderString("biolink:" + pred, input))
-                                    : ["biolink:" + edge.association.predicate]
-                            }
-                        }
-                    }
-                }
-            }
-        } else {
             qg = {
                 "message": {
                     "query_graph": {
@@ -106,7 +69,6 @@ module.exports = class TRAPIQueryBuilder {
                     }
                 }
             }
-        }
         return qg;
     }
 


### PR DESCRIPTION
*(Continuation of #30 addressing #26 and biothings/BioThings_Explorer_TRAPI#147)*

This PR moves all templating support to a new query builder, `template_query_builder.js`. Support is improved for arbitrarily templating JSON-type request bodies.

Additionally, a new filter function, `wrap`, is implemented, in order to wrap a string (or strings in an array) between two strings. Takes a start an end argument, which are the strings added to the start and end of the input string. If only start is supplied, end will use the same string as start.

This PR must be merged with the following additional PRs in order to work:

- biothings/bte_trapi_query_graph_handler#40
- biothings/smartapi-kg.js#41