### PR TITLE
Annotate input as well as output entity IDs during query process.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "homepage": "https://github.com/biothings/call-apis.js#readme",
   "dependencies": {
     "@biothings-explorer/api-response-transform": "^1.12.0",
-    "biomedical_id_resolver": "^3.10.0",
     "axios": "^0.21.1",
+    "biomedical_id_resolver": "^3.10.0",
     "debug": "^4.3.1",
     "husky": "^4.3.8",
     "nunjucks": "^3.2.3"

--- a/src/query.js
+++ b/src/query.js
@@ -207,7 +207,7 @@ module.exports = class APIQueryDispathcer {
         } else {
             res = await resolver.resolveSRI(groupedIDs);
             attributes = await resolver.getAttributes(groupedIDs);
-            debug(`Attributes retrieved ${JSON.stringify(attributes)}`);
+            // debug(`Attributes retrieved ${JSON.stringify(attributes)}`);
         }
         result.map(item => {
             if (item && item !== undefined) {

--- a/src/query.js
+++ b/src/query.js
@@ -140,30 +140,61 @@ module.exports = class APIQueryDispathcer {
             if (item && item.$edge_metadata) {
                 const output_type = item.$edge_metadata.output_type;
                 if (!(output_type in output_ids)) {
-                    output_ids[output_type] = [];
+                    output_ids[output_type] = new Set();
                 }
-                output_ids[output_type].push(item.$output.original);
+                output_ids[output_type].add(item.$output.original);
             }
-        })
+        });
+        for (const key in output_ids) {
+            output_ids[key] = [...output_ids[key]];
+        }
         return output_ids;
+    }
+
+    _groupIDsBySemanticType(result) {
+        const ids = {};
+        result.map(item => {
+            if (item && item.$edge_metadata) {
+                //INPUTS
+                const input_type = item.$edge_metadata.input_type;
+                if (!(input_type in ids)) {
+                    ids[input_type] = new Set();
+                }
+                ids[input_type].add(item.$input.original);
+                // OUTPUTS
+                const output_type = item.$edge_metadata.output_type;
+                if (!(output_type in ids)) {
+                    ids[output_type] = new Set();
+                }
+                ids[output_type].add(item.$output.original);
+            }
+        });
+        for (const key in ids) {
+            ids[key] = [...ids[key]];
+        }
+        return ids;
     }
 
     /**
      * Add equivalent ids to all output using biomedical-id-resolver service
      */
     async _annotate(result, enable = true) {
-        const grpedIDs = this._groupOutputIDsBySemanticType(result);
+        // const grpedIDs = this._groupOutputIDsBySemanticType(result);
+        const groupedIDs = this._groupIDsBySemanticType(result);
+        debug(`GROUPED IDS ${JSON.stringify(groupedIDs)}`);
         let res;
         if (enable === false) {
-            res = resolver.generateInvalidBioentities(grpedIDs);
+            res = resolver.generateInvalidBioentities(groupedIDs);
         } else {
             // const biomedical_resolver = new resolver.Resolver("biolink");
             // res = await biomedical_resolver.resolve(grpedIDs);
-            res = await resolver.resolveSRI(grpedIDs);
+            res = await resolver.resolveSRI(groupedIDs);
         }
+        // debug(`RESULT ${JSON.stringify(res)}`);
         result.map(item => {
             if (item && item !== undefined) {
                 item.$output.obj = res[item.$output.original];
+                item.$input.obj = res[item.$input.original];
             }
         });
         return result;

--- a/src/query.js
+++ b/src/query.js
@@ -215,10 +215,10 @@ module.exports = class APIQueryDispathcer {
                 item.$input.obj = res[item.$input.original];
             }
             //add attributes
-            if (attributes && Object.hasOwnProperty.call(attributes, item.$input.original)) {
+            if (attributes && item && Object.hasOwnProperty.call(attributes, item.$input.original)) {
                 item.$input.obj[0]['attributes'] = attributes[item.$input.original]
             }
-            if (attributes && Object.hasOwnProperty.call(attributes, item.$output.original)) {
+            if (attributes && item && Object.hasOwnProperty.call(attributes, item.$output.original)) {
                 item.$output.obj[0]['attributes'] = attributes[item.$output.original]
             }
         });

--- a/src/query.js
+++ b/src/query.js
@@ -179,18 +179,13 @@ module.exports = class APIQueryDispathcer {
      * Add equivalent ids to all output using biomedical-id-resolver service
      */
     async _annotate(result, enable = true) {
-        // const grpedIDs = this._groupOutputIDsBySemanticType(result);
         const groupedIDs = this._groupIDsBySemanticType(result);
-        debug(`GROUPED IDS ${JSON.stringify(groupedIDs)}`);
         let res;
         if (enable === false) {
             res = resolver.generateInvalidBioentities(groupedIDs);
         } else {
-            // const biomedical_resolver = new resolver.Resolver("biolink");
-            // res = await biomedical_resolver.resolve(grpedIDs);
             res = await resolver.resolveSRI(groupedIDs);
         }
-        // debug(`RESULT ${JSON.stringify(res)}`);
         result.map(item => {
             if (item && item !== undefined) {
                 item.$output.obj = res[item.$output.original];

--- a/src/query.js
+++ b/src/query.js
@@ -24,8 +24,6 @@ module.exports = class APIQueryDispathcer {
     constructor(edges) {
         this.edges = edges;
         this.logs = [];
-        this.biolink = new biolink.BioLink();
-        this.biolink.loadSync();
     }
 
     async _queryBucket(queries) {
@@ -218,11 +216,9 @@ module.exports = class APIQueryDispathcer {
             }
             //add attributes
             if (attributes && Object.hasOwnProperty.call(attributes, item.$input.original)) {
-                debug(`(I) Attributes added to ${item.$input.original}`);
                 item.$input.obj[0]['attributes'] = attributes[item.$input.original]
             }
             if (attributes && Object.hasOwnProperty.call(attributes, item.$output.original)) {
-                debug(`(O) Attributes added to ${item.$output.original}`);
                 item.$output.obj[0]['attributes'] = attributes[item.$output.original]
             }
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,1 +1,0 @@
-../../../scripts/tsconfig.json_call-apis

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,1 @@
+../../../scripts/tsconfig.json_call-apis


### PR DESCRIPTION
With the new attribute getter attributes are populated when a node is annotated, and previously only the output was annotated.  this combines output and input ids in the same batch to annotate both and get attributes for both. 