### PR TITLE
feat: allow limiting of query results

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 16.x
 
     - name: npm install, generate coverage report
       run: |

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,1 @@
-exports.MAX_RESULTS_PER_EDGE = 1000;
+exports.MAX_RESULTS_PER_EDGE = -1;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+exports.MAX_RESULTS_PER_EDGE = 1000;


### PR DESCRIPTION
Related to https://github.com/biothings/BioThings_Explorer_TRAPI/issues/363. 

How the limiting works: Each query bucket, it checks the results array to see if the number of results has exceeded the maxResultsPerEdge. If it has, stop further querying and truncate the results array down to that number. ~~Default value is 1000 and is stored in new config file.~~ Turned off by default.