### PR TITLE
Identify BTE w/ User-Agent in API calls

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -32,6 +32,10 @@ module.exports = class APIQueryDispathcer {
         const res = await Promise.allSettled(queries.map(async query => {
             try {
                 const query_config = query.getConfig();
+                const userAgent = `BTE/${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'} Node/${process.version} ${process.platform}`
+                query_config.headers = query_config.headers
+                    ? { ...query_config.headers, "User-Agent": userAgent }
+                    : { "User-Agent": userAgent }
                 debug(query_config);
                 if (query_config.url.includes("arax.ncats.io")) {
                     //delay 1s specifically for RTX KG2 at https://arax.ncats.io/api/rtxkg2/v1.2


### PR DESCRIPTION
*(addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/376)*

Generates a User-Agent header for API calls. As BTE doesn't have a strict semantic version number, version is used to refer to prod or dev. Uses the following format:

`BTE/version Node/version platform`

A call from BTE's production server might appear as `BTE/prod Node/v16.12.0 linux` while a call from a developer's local instance on a Mac might appear as `BTE/dev Node/v16.7.0 darwin`.