### PR TITLE
User friendly summary logs

### DIFF
--- a/src/log_entry.js
+++ b/src/log_entry.js
@@ -1,9 +1,12 @@
+const _ = require('lodash');
+
 module.exports = class LogEntry {
 
-    constructor(level = "DEBUG", code = null, message = null) {
+    constructor(level = "DEBUG", code = null, message = null, data = null) {
         this.level = level;
         this.message = message;
         this.code = code;
+        this.data = data;
     }
 
     getLog() {
@@ -11,7 +14,9 @@ module.exports = class LogEntry {
             timestamp: new Date().toISOString(),
             level: this.level,
             message: this.message,
-            code: this.code
+            code: this.code,
+            data: this.data,
+            toJSON() { return _.omit(this, ['data', 'toJSON']); }
         }
     }
 }


### PR DESCRIPTION
First pass addressing biothings/BioThings_Explorer_TRAPI#328. Part of 4 related PRs:

- biothings/BioThings_Explorer_TRAPI/pull/390
- biothings/call-apis.js/pull/38
- biothings/bte_trapi_query_graph_handler/pull/85
- biothings/smartapi-kg.js/pull/44

This PR makes certain subquery logs more concise/readable.