### PR TITLE
Skip sub-queries to APIs which appear unavailable

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -34,8 +34,8 @@ module.exports = class APIQueryDispathcer {
             let query_config, n_inputs, query_info, edge_operation;
             try {
                 query_config = query.getConfig();
-                if (unavailableAPIs[query_config.url]) {
-                    unavailableAPIs[query_config.url] += 1;
+                if (unavailableAPIs[query.edge.query_operation.server]) {
+                    unavailableAPIs[query.edge.query_operation.server] += 1;
                     return undefined;
                 }
                 n_inputs = Array.isArray(query.edge.input) ? query.edge.input.length : 1;
@@ -81,7 +81,7 @@ module.exports = class APIQueryDispathcer {
                     debug("This query needs to be paginated");
                 }
                 // const console_msg = `Succesfully made the following query: ${JSON.stringify(query_config)}`;
-                const log_msg =  `call-apis: Successful ${query_config.method.toUpperCase()} ${query_config.url} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}`
+                const log_msg =  `call-apis: Successful ${query_config.method.toUpperCase()} ${query.edge.query_operation.server} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}`
                 // if (log_msg.length > 1000) {
                 //     log_msg = log_msg.substring(0, 1000) + "...";
                 // }
@@ -111,9 +111,9 @@ module.exports = class APIQueryDispathcer {
                 return transformed;
             } catch (error) {
                 if ((error.response && error.response.status >= 502) || error.code === 'ECONNABORTED') {
-                    const errorMessage = `${query_config.url} appears to be unavailable. Queries to it will be skipped.`;
+                    const errorMessage = `${query.edge.query_operation.server} appears to be unavailable. Queries to it will be skipped.`;
                     debug(errorMessage);
-                    unavailableAPIs[query_config.url] = 1;
+                    unavailableAPIs[query.edge.query_operation.server] = 1;
                 }
                 debug(
                     `Failed to make to following query: ${JSON.stringify(
@@ -121,7 +121,7 @@ module.exports = class APIQueryDispathcer {
                     )}. The error is ${error.toString()}`,
                 );
 
-                const log_msg =  `call-apis: Failed ${query_config.method.toUpperCase()} ${query_config.url} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}: (${error.toString()})`
+                const log_msg =  `call-apis: Failed ${query_config.method.toUpperCase()} ${query.edge.query_operation.server} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}: (${error.toString()})`
                 this.logs.push(
                     new LogEntry(
                         "ERROR",


### PR DESCRIPTION
*(addresses biothings/BioThings_Explorer_TRAPI/issues/392)*

APIs to which a sub-query times out or which returns an internal server error indicative of API unavailability (HTTP status 502 or higher) are added to an object of unavailable APIs, and subsequently skipped for the rest of the handling of the given BTE query. The number of times an API is skipped is also tracked using this object.

Requires biothings/bte_trapi_query_graph_handler/pull/92