### PR TITLE
Refactor: Conform variable names to standardized vocabulary (pass#1)

### DIFF
--- a/src/builder/builde_factory.js
+++ b/src/builder/builde_factory.js
@@ -4,16 +4,16 @@ const template_builder = require("./template_query_builder")
 const debug = require("debug")("bte:call-apis:query");
 
 
-const builder_factory = (edge) => {
-    if ('tags' in edge && edge.tags.includes('bte-trapi')) {
+const builder_factory = (APIEdge) => {
+    if ('tags' in APIEdge && APIEdge.tags.includes('bte-trapi')) {
         debug(`using trapi builder now`)
-        return new trapi_builder(edge);
-    } else if (edge.query_operation.useTemplating) {
+        return new trapi_builder(APIEdge);
+    } else if (APIEdge.query_operation.useTemplating) {
         debug("using template builder");
-        return new template_builder(edge);
+        return new template_builder(APIEdge);
     }
     debug('using default builder')
-    return new default_builder(edge);
+    return new default_builder(APIEdge);
 }
 
 module.exports = builder_factory;

--- a/src/builder/template_query_builder.js
+++ b/src/builder/template_query_builder.js
@@ -8,27 +8,27 @@ nunjucksConfig(env);
 module.exports = class TemplateQueryBuilder {
   /**
    * Constructor for Query Builder
-   * @param {object} edge - BTE Edge object with input field provided
+   * @param {object} APIEdge - BTE Edge object with input field provided
    */
-  constructor(edge) {
+  constructor(APIEdge) {
     this.start = 0;
     this.hasNext = false;
-    this.edge = edge;
+    this.APIEdge = APIEdge;
   }
 
   getUrl() {
-    return this.edge.query_operation.server + this.edge.query_operation.path;
+    return this.APIEdge.query_operation.server + this.APIEdge.query_operation.path;
   }
 
-  _getUrl(edge, input) {
-    let server = edge.query_operation.server;
+  _getUrl(APIEdge, input) {
+    let server = APIEdge.query_operation.server;
     if (server.endsWith("/")) {
       server = server.substring(0, server.length - 1);
     }
-    let path = edge.query_operation.path;
-    if (Array.isArray(edge.query_operation.path_params)) {
-      edge.query_operation.path_params.map(param => {
-        const val = edge.query_operation.params[param];
+    let path = APIEdge.query_operation.path;
+    if (Array.isArray(APIEdge.query_operation.path_params)) {
+      APIEdge.query_operation.path_params.map(param => {
+        const val = APIEdge.query_operation.params[param];
         path = nunjucks.renderString(path.replace("{" + param + "}", val), input);
       });
     }
@@ -38,23 +38,23 @@ module.exports = class TemplateQueryBuilder {
   /**
    * Construct input based on method and inputSeparator
    */
-  _getInput(edge) {
-    return edge.input;
+  _getInput(APIEdge) {
+    return APIEdge.input;
   }
 
   /**
    * Construct parameters for API calls
    */
-  _getParams(edge, input) {
+  _getParams(APIEdge, input) {
     const params = {};
-    Object.keys(edge.query_operation.params).map(param => {
-      if (Array.isArray(edge.query_operation.path_params) && edge.query_operation.path_params.includes(param)) {
+    Object.keys(APIEdge.query_operation.params).map(param => {
+      if (Array.isArray(APIEdge.query_operation.path_params) && APIEdge.query_operation.path_params.includes(param)) {
         return;
       }
-      if (typeof edge.query_operation.params[param] === "string") {
-        params[param] = nunjucks.renderString(edge.query_operation.params[param], input);
+      if (typeof APIEdge.query_operation.params[param] === "string") {
+        params[param] = nunjucks.renderString(APIEdge.query_operation.params[param], input);
       } else {
-        params[param] = edge.query_operation.params[param];
+        params[param] = APIEdge.query_operation.params[param];
       }
     });
     return params;
@@ -63,11 +63,11 @@ module.exports = class TemplateQueryBuilder {
   /**
    * Construct request body for API calls
    */
-  _getRequestBody(edge, input) {
-    if (edge.query_operation.request_body !== undefined && "body" in edge.query_operation.request_body) {
-      let body = edge.query_operation.request_body.body;
+  _getRequestBody(APIEdge, input) {
+    if (APIEdge.query_operation.request_body !== undefined && "body" in APIEdge.query_operation.request_body) {
+      let body = APIEdge.query_operation.request_body.body;
       let data;
-      if (edge.query_operation.requestBodyType === "object") {
+      if (APIEdge.query_operation.requestBodyType === "object") {
         data = JSON.parse(nunjucks.renderString(body, input));
       } else {
         data = Object.keys(body).reduce((accumulator, key) => {
@@ -83,12 +83,12 @@ module.exports = class TemplateQueryBuilder {
    * Construct the request config for Axios reqeust.
    */
   constructAxiosRequestConfig() {
-    const input = this._getInput(this.edge);
+    const input = this._getInput(this.APIEdge);
     const config = {
-      url: this._getUrl(this.edge, input),
-      params: this._getParams(this.edge, input),
-      data: this._getRequestBody(this.edge, input),
-      method: this.edge.query_operation.method,
+      url: this._getUrl(this.APIEdge, input),
+      params: this._getParams(this.APIEdge, input),
+      data: this._getRequestBody(this.APIEdge, input),
+      method: this.APIEdge.query_operation.method,
       timeout: 50000,
     };
     this.config = config;
@@ -96,7 +96,7 @@ module.exports = class TemplateQueryBuilder {
   }
 
   needPagination(apiResponse) {
-    if (this.edge.query_operation.method === "get" && this.edge.tags.includes("biothings")) {
+    if (this.APIEdge.query_operation.method === "get" && this.APIEdge.tags.includes("biothings")) {
       if (apiResponse.total > this.start + apiResponse.hits.length) {
         if (this.start + apiResponse.hits.length < 10000) {
           this.hasNext = true;
@@ -110,7 +110,7 @@ module.exports = class TemplateQueryBuilder {
 
   getNext() {
     this.start = Math.min(this.start + 1000, 9999);
-    const config = this.constructAxiosRequestConfig(this.edge);
+    const config = this.constructAxiosRequestConfig(this.APIEdge);
     config.params.from = this.start;
     if (config.params.size + this.start > 10000) {
       config.params.size = 10000 - this.start;
@@ -121,7 +121,7 @@ module.exports = class TemplateQueryBuilder {
 
   getConfig() {
     if (this.hasNext === false) {
-      return this.constructAxiosRequestConfig(this.edge);
+      return this.constructAxiosRequestConfig(this.APIEdge);
     }
     return this.getNext();
   }

--- a/src/builder/trapi_query_builder.js
+++ b/src/builder/trapi_query_builder.js
@@ -8,27 +8,27 @@ nunjucksConfig(env);
 module.exports = class TRAPIQueryBuilder {
     /**
      * Constructor for Query Builder
-     * @param {object} edge - BTE Edge object with input field provided
+     * @param {object} APIEdge - BTE Edge object with input field provided
      */
-    constructor(edge) {
+    constructor(APIEdge) {
         this.start = 0
         this.hasNext = false
-        this.edge = edge;
+        this.APIEdge = APIEdge;
     }
 
     getUrl() {
-        return this.edge.query_operation.server + this.edge.query_operation.path;
+        return this.APIEdge.query_operation.server + this.APIEdge.query_operation.path;
     }
 
-    _getUrl(edge, input) {
-        let server = edge.query_operation.server;
+    _getUrl(APIEdge, input) {
+        let server = APIEdge.query_operation.server;
         if (server.endsWith('/')) {
             server = server.substring(0, server.length - 1)
         };
-        let path = edge.query_operation.path;
-        if (Array.isArray(edge.query_operation.path_params)) {
-              edge.query_operation.path_params.map(param => {
-                const val = edge.query_operation.params[param];
+        let path = APIEdge.query_operation.path;
+        if (Array.isArray(APIEdge.query_operation.path_params)) {
+              APIEdge.query_operation.path_params.map(param => {
+                const val = APIEdge.query_operation.params[param];
                 path = path.replace("{" + param + "}", val).replace("{inputs[0]}", input);
               });
         }
@@ -38,31 +38,31 @@ module.exports = class TRAPIQueryBuilder {
     /**
      * Construct input based on method and inputSeparator
      */
-    _getInput(edge) {
-        return edge.input;
+    _getInput(APIEdge) {
+        return APIEdge.input;
     }
 
     /**
      * Construct TRAPI request body
      */
-    _getRequestBody(edge, input) {
+    _getRequestBody(APIEdge, input) {
         const qg = {
             "message": {
                 "query_graph": {
                     "nodes": {
                         "n0": {
                             "ids": Array.isArray(input) ? input : [input],
-                            "categories": ["biolink:" + edge.association.input_type]
+                            "categories": ["biolink:" + APIEdge.association.input_type]
                         },
                         "n1": {
-                            "categories": ["biolink:" + edge.association.output_type]
+                            "categories": ["biolink:" + APIEdge.association.output_type]
                         }
                     },
-                    "edges": {
+                    "APIEdges": {
                         "e01": {
                             "subject": "n0",
                             "object": "n1",
-                            "predicates": ["biolink:" + edge.association.predicate]
+                            "predicates": ["biolink:" + APIEdge.association.predicate]
                         }
                     }
                 }
@@ -76,11 +76,11 @@ module.exports = class TRAPIQueryBuilder {
      * Construct the request config for Axios reqeust.
      */
     constructAxiosRequestConfig() {
-        const input = this._getInput(this.edge);
+        const input = this._getInput(this.APIEdge);
         const config = {
-            url: this._getUrl(this.edge, input),
-            data: this._getRequestBody(this.edge, input),
-            method: this.edge.query_operation.method,
+            url: this._getUrl(this.APIEdge, input),
+            data: this._getRequestBody(this.APIEdge, input),
+            method: this.APIEdge.query_operation.method,
             timeout: 50000,
             headers: {
                 'Content-Type': 'application/json'
@@ -96,13 +96,13 @@ module.exports = class TRAPIQueryBuilder {
     }
 
     getNext() {
-        const config = this.constructAxiosRequestConfig(this.edge);
+        const config = this.constructAxiosRequestConfig(this.APIEdge);
         return config;
     }
 
     getConfig() {
         if (this.hasNext === false) {
-            return this.constructAxiosRequestConfig(this.edge);
+            return this.constructAxiosRequestConfig(this.APIEdge);
         }
         return this.getNext();
     }

--- a/src/builder/trapi_query_builder.js
+++ b/src/builder/trapi_query_builder.js
@@ -58,7 +58,7 @@ module.exports = class TRAPIQueryBuilder {
                             "categories": ["biolink:" + APIEdge.association.output_type]
                         }
                     },
-                    "APIEdges": {
+                    "edges": {
                         "e01": {
                             "subject": "n0",
                             "object": "n1",

--- a/src/query.js
+++ b/src/query.js
@@ -15,15 +15,15 @@ async function delay_here(sec) {
 }
 
 /**
- * Make API Queries based on input BTE Edges, collect and align the results into BioLink Model
+ * Make API Queries based on input BTE Edges, collect and align the records into BioLink Model
  */
-module.exports = class APIQueryDispathcer {
+module.exports = class APIQueryDispatcher {
     /**
      * Construct inputs for APIQueryDispatcher
-     * @param {array} edges - an array of BTE edges with input added
+     * @param {array} APIEdges - an array of BTE edges with input added
      */
-    constructor(edges) {
-        this.edges = edges;
+    constructor(APIEdges) {
+        this.APIEdges = APIEdges;
         this.logs = [];
     }
 
@@ -33,16 +33,16 @@ module.exports = class APIQueryDispathcer {
             let query_config, n_inputs, query_info, edge_operation;
             try {
                 query_config = query.getConfig();
-                n_inputs = Array.isArray(query.edge.input) ? query.edge.input.length : 1;
+                n_inputs = Array.isArray(query.APIEdge.input) ? query.APIEdge.input.length : 1;
                 query_info = {
-                    edge_id: query.edge.reasoner_edge.qEdge.id,
+                    edge_id: query.APIEdge.reasoner_edge.qEdge.id,
                     url: query_config.url,
-                    subject: query.edge.association.input_type,
-                    object: query.edge.association.output_type,
-                    predicate: query.edge.association.predicate,
+                    subject: query.APIEdge.association.input_type,
+                    object: query.APIEdge.association.output_type,
+                    predicate: query.APIEdge.association.predicate,
                     ids: n_inputs
                 }
-                edge_operation = `${query.edge.association.input_type} > ${query.edge.association.predicate} > ${query.edge.association.output_type}`
+                edge_operation = `${query.APIEdge.association.input_type} > ${query.APIEdge.association.predicate} > ${query.APIEdge.association.output_type}`
             } catch (error) {
                 debug('Query configuration error, query skipped');
                 this.logs.push(
@@ -67,11 +67,11 @@ module.exports = class APIQueryDispathcer {
                     await delay_here(1);
                 }
                 const queryResponse = dryrun_only ? {data: []} : await axios(query_config);
-                const res = {
+                const unTransformedHits = {
                     response: queryResponse.data,
-                    edge: query.edge,
+                    edge: query.APIEdge,
                 };
-                if (query.needPagination(res.response)) {
+                if (query.needPagination(unTransformedHits.response)) {
                     this.logs.push(new LogEntry("DEBUG", null, "call-apis: This query needs to be paginated").getLog());
                     debug("This query needs to be paginated");
                 }
@@ -80,8 +80,8 @@ module.exports = class APIQueryDispathcer {
                 // if (log_msg.length > 1000) {
                 //     log_msg = log_msg.substring(0, 1000) + "...";
                 // }
-                const tf_obj = new tf.Transformer(res);
-                const transformed = await tf_obj.transform();
+                const tf_obj = new tf.Transformer(unTransformedHits);
+                const transformedRecords = await tf_obj.transform();
                 debug(log_msg);
                 this.logs.push(
                     new LogEntry(
@@ -90,20 +90,20 @@ module.exports = class APIQueryDispathcer {
                         log_msg,
                         {
                             type: "query",
-                            hits: transformed.length,
+                            hits: transformedRecords.length,
                             ...query_info,
                         }
                     ).getLog(),
                 );
-                debug(`After transformation, BTE is able to retrieve ${transformed.length} hits!`);
+                debug(`After transformation, BTE is able to retrieve ${transformedRecords.length} records!`);
                 this.logs.push(
                     new LogEntry(
                         "DEBUG",
                         null,
-                        `call-apis: After transformation, BTE is able to retrieve ${transformed.length} hits!`,
+                        `call-apis: After transformation, BTE is able to retrieve ${transformedRecords.length} records!`,
                     ).getLog(),
                 );
-                return transformed;
+                return transformedRecords;
             } catch (error) {
                 debug(
                     `Failed to make to following query: ${JSON.stringify(
@@ -149,8 +149,8 @@ module.exports = class APIQueryDispathcer {
         })
     }
 
-    _constructQueries(edges) {
-        return edges.map(edge => {
+    _constructQueries(APIEdges) {
+        return APIEdges.map(edge => {
             return qb(edge);
         });
     }
@@ -163,51 +163,53 @@ module.exports = class APIQueryDispathcer {
     async query(resolveOutputIDs = true) {
         debug(`Resolving ID feature is turned ${(resolveOutputIDs) ? 'on' : 'off'}`)
         this.logs.push(new LogEntry("DEBUG", null, `call-apis: Resolving ID feature is turned ${(resolveOutputIDs) ? 'on' : 'off'}`).getLog());
-        debug(`Number of BTE Edges received is ${this.edges.length}`);
-        this.logs.push(new LogEntry("DEBUG", null, `call-apis: Number of BTE Edges received is ${this.edges.length}`).getLog());
-        let queryResult = [];
-        const queries = this._constructQueries(this.edges);
+        debug(`Number of BTE Edges received is ${this.APIEdges.length}`);
+        this.logs.push(new LogEntry("DEBUG", null, `call-apis: Number of API Edges received is ${this.APIEdges.length}`).getLog());
+        let queryRecords = [];
+        const queries = this._constructQueries(this.APIEdges);
         this._constructQueue(queries);
         while (this.queue.queue.length > 0) {
             const bucket = this.queue.queue[0].getBucket();
-            let res = await this._queryBucket(bucket);
-            queryResult = [...queryResult, ...res];
+            let newHits = await this._queryBucket(bucket);
+            queryRecords = [...queryRecords, ...newHits];
             this._checkIfNext(bucket);
         }
         debug("query completes.")
-        const mergedResult = this._merge(queryResult);
+        const mergedRecords = this._merge(queryRecords);
         debug("Start to use id resolver module to annotate output ids.")
-        const annotatedResult = await this._annotate(mergedResult, resolveOutputIDs);
+        const annotatedRecords = await this._annotate(mergedRecords, resolveOutputIDs);
         debug("id annotation completes");
         debug("Query completes");
         this.logs.push(new LogEntry("DEBUG", null, "call-apis: Query completes").getLog());
-        return annotatedResult;
+        return annotatedRecords;
     }
 
     /**
-     * Merge the results into a single array from Promise.allSettled
+     * Merge the records into a single array from Promise.allSettled
      */
-    _merge(queryResult) {
-        let result = [];
-        queryResult.map(res => {
-            if (res.status === "fulfilled" && !(res.value === undefined)) {
-                result = [...result, ...res.value];
+    _merge(queryRecords) {
+        let mergedRecords = [];
+        queryRecords.map(record => {
+            if (record.status === "fulfilled" && !(record.value === undefined)) {
+                mergedRecords = [...mergedRecords, ...record.value];
             }
         });
-        debug(`Total number of results returned for this query is ${result.length}`)
+        debug(`Total number of records returned for this query is ${mergedRecords.length}`)
         this.logs.push(
           new LogEntry(
             "DEBUG",
             null,
-            `call-apis: Total number of results returned for this query is ${result.length}`,
+            `call-apis: Total number of records returned for this query is ${mergedRecords.length}`,
           ).getLog(),
         );
-        return result;
+        return mergedRecords;
     }
 
-    _groupOutputIDsBySemanticType(result) {
+    _groupOutputIDsBySemanticType(record
+        ) {
         const output_ids = {};
-        result.map(item => {
+        record
+        .map(item => {
             if (item && item.$edge_metadata) {
                 const output_type = item.$edge_metadata.output_type;
                 if (!(output_type in output_ids)) {
@@ -222,63 +224,63 @@ module.exports = class APIQueryDispathcer {
         return output_ids;
     }
 
-    _groupIDsBySemanticType(result) {
-        const ids = {};
-        result.map(item => {
-            if (item && item.$edge_metadata) {
+    _groupCuriesBySemanticType(records) {
+        const curies = {};
+        records.map(record => {
+            if (record && record.$edge_metadata) {
                 //INPUTS
-                const input_type = item.$edge_metadata.input_type;
-                if (!(input_type in ids)) {
-                    ids[input_type] = new Set();
+                const input_type = record.$edge_metadata.input_type;
+                if (!(input_type in curies)) {
+                    curies[input_type] = new Set();
                 }
-                ids[input_type].add(item.$input.original);
+                curies[input_type].add(record.$input.original);
                 // OUTPUTS
-                const output_type = item.$edge_metadata.output_type;
-                if (!(output_type in ids)) {
-                    ids[output_type] = new Set();
+                const output_type = record.$edge_metadata.output_type;
+                if (!(output_type in curies)) {
+                    curies[output_type] = new Set();
                 }
-                ids[output_type].add(item.$output.original);
+                curies[output_type].add(record.$output.original);
             }
         });
-        for (const key in ids) {
-            //remove undefined ids
-            let good_ids = [...ids[key]].filter(id => id !== undefined);
-            ids[key] = good_ids;
+        for (const semanticType in curies) {
+            //remove undefined curies
+            let good_curies = [...curies[semanticType]].filter(id => id !== undefined);
+            curies[semanticType] = good_curies;
         }
-        return ids;
+        return curies;
     }
 
     /**
      * Add equivalent ids to all entities using biomedical-id-resolver service
      */
-    async _annotate(result, enable = true) {
-        const groupedIDs = this._groupIDsBySemanticType(result);
+    async _annotate(records, resolveOutputIDs = true) {
+        const groupedCuries = this._groupCuriesBySemanticType(records);
         let res;
         let attributes;
-        if (enable === false) {
-            res = resolver.generateInvalidBioentities(groupedIDs);
+        if (resolveOutputIDs === false) {
+            res = resolver.generateInvalidBioentities(groupedCuries);
         } else {
-            res = await resolver.resolveSRI(groupedIDs);
-            attributes = await resolver.getAttributes(groupedIDs);
+            res = await resolver.resolveSRI(groupedCuries);
+            attributes = await resolver.getAttributes(groupedCuries);
         }
-        result.map(item => {
-            if (item && item !== undefined) {
-                item.$output.obj = res[item.$output.original];
-                item.$input.obj = res[item.$input.original];
+        records.map(record => {
+            if (record && record !== undefined) {
+                record.$output.obj = res[record.$output.original];
+                record.$input.obj = res[record.$input.original];
             }
             //add attributes
-            if (attributes && item && Object.hasOwnProperty.call(attributes, item.$input.original)) {
-                if (item instanceof ResolvableBioEntity) {
-                    item.$input.obj[0]['attributes'] = attributes[item.$input.original]
+            if (attributes && record && Object.hasOwnProperty.call(attributes, record.$input.original)) {
+                if (record instanceof ResolvableBioEntity) {
+                    record.$input.obj[0]['attributes'] = attributes[record.$input.original]
                 }
             }
-            if (attributes && item && Object.hasOwnProperty.call(attributes, item.$output.original)) {
-                if (item instanceof ResolvableBioEntity){
-                    item.$output.obj[0]['attributes'] = attributes[item.$output.original]
+            if (attributes && record && Object.hasOwnProperty.call(attributes, record.$output.original)) {
+                if (record instanceof ResolvableBioEntity){
+                    record.$output.obj[0]['attributes'] = attributes[record.$output.original]
                 }
             }
         });
-        return result;
+        return records;
     }
 
 }

--- a/src/query.js
+++ b/src/query.js
@@ -80,7 +80,7 @@ module.exports = class APIQueryDispatcher {
                     debug("This query needs to be paginated");
                 }
                 // const console_msg = `Succesfully made the following query: ${JSON.stringify(query_config)}`;
-                const log_msg =  `call-apis: Successful ${query_config.method.toUpperCase()} ${query.edge.query_operation.server} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}`
+                const log_msg =  `call-apis: Successful ${query_config.method.toUpperCase()} ${query.APIEdge.query_operation.server} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}`
                 // if (log_msg.length > 1000) {
                 //     log_msg = log_msg.substring(0, 1000) + "...";
                 // }
@@ -110,9 +110,9 @@ module.exports = class APIQueryDispatcher {
                 return transformedRecords;
             } catch (error) {
                 if ((error.response && error.response.status >= 502) || error.code === 'ECONNABORTED') {
-                    const errorMessage = `${query.edge.query_operation.server} appears to be unavailable. Queries to it will be skipped.`;
+                    const errorMessage = `${query.APIEdge.query_operation.server} appears to be unavailable. Queries to it will be skipped.`;
                     debug(errorMessage);
-                    unavailableAPIs[query.edge.query_operation.server] = 1;
+                    unavailableAPIs[query.APIEdge.query_operation.server] = 1;
                 }
                 debug(
                     `Failed to make to following query: ${JSON.stringify(
@@ -120,7 +120,7 @@ module.exports = class APIQueryDispatcher {
                     )}. The error is ${error.toString()}`,
                 );
 
-                const log_msg =  `call-apis: Failed ${query_config.method.toUpperCase()} ${query.edge.query_operation.server} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}: (${error.toString()})`
+                const log_msg =  `call-apis: Failed ${query_config.method.toUpperCase()} ${query.APIEdge.query_operation.server} (${n_inputs} ID${n_inputs > 1 ? 's' : ''}): ${edge_operation}: (${error.toString()})`
                 this.logs.push(
                     new LogEntry(
                         "ERROR",


### PR DESCRIPTION
This PR is a first-pass attempt to address biothings/BioThings_Explorer_TRAPI/issues/379.

No actual behavior has been changed. Variable names have been changed to better reflect a set of standardized vocabulary for internal data structures (which should better reflect their purpose and relationship to external data structures).

Due to some data structures passed between modules, this PR requires biothings/bte_trapi_query_graph_handler/pull/93.

This PR will require additional review and discussion to ensure that there are no additional changes that should be made, etc.
