### PR TITLE
Sub-query time elapsed logging

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -95,7 +95,7 @@ module.exports = class APIQueryDispatcher {
                   query.APIEdge.query_operation.server
                 } (${n_inputs} ID${n_inputs > 1 ? "s" : ""}): ${edge_operation} (obtained ${
                   transformedRecords.length
-                } record${transformedRecords.length === 1 ? "s" : ""}, took ${timeElapsed}${timeUnits})`;
+                } record${transformedRecords.length === 1 ? "" : "s"}, took ${timeElapsed}${timeUnits})`;
                 // if (log_msg.length > 1000) {
                 //     log_msg = log_msg.substring(0, 1000) + "...";
                 // }

--- a/src/query.js
+++ b/src/query.js
@@ -6,6 +6,7 @@ const resolver = require("biomedical_id_resolver");
 const debug = require("debug")("bte:call-apis:query");
 const LogEntry = require("./log_entry");
 const { ResolvableBioEntity } = require("biomedical_id_resolver/built/bioentity/valid_bioentity");
+const { performance } = require('perf_hooks');
 
 
 async function delay_here(sec) {


### PR DESCRIPTION
*(addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/425)*

Adds timing to queries, so query success logs read like this:

```
"call-apis: Successful POST https://automat.renci.org/pharos/1.2 (7 IDs): Gene > activity_increased_by > SmallMolecule (obtained 0 records, took 140ms)"
```

And when all queries complete for a qEdge, the log now reflects the actual time elapsed for all queries for the qEdge:

```
call-apis: qEdge queries complete in 849ms
```

Units switch from milliseconds to seconds when appropriate.