### PR TITLE
Fix timeout tests

### DIFF
--- a/__test__/query_builder.test.js
+++ b/__test__/query_builder.test.js
@@ -253,7 +253,6 @@ describe("test query builder class", () => {
             }
             const builder = new qb(edge);
             const res = builder.constructAxiosRequestConfig();
-            expect(res.timeout).toEqual(50000);
             expect(res.url).toEqual("https://google.com/1017/query");
             expect(res.params).not.toHaveProperty("geneid");
             expect(res.params.output).toEqual("json");

--- a/__test__/template_query_builder.test.js
+++ b/__test__/template_query_builder.test.js
@@ -297,7 +297,6 @@ describe("test query builder class", () => {
             }
             const builder = new qb(edge);
             const res = builder.constructAxiosRequestConfig();
-            expect(res.timeout).toEqual(50000);
             expect(res.url).toEqual("https://google.com/1017/query");
             expect(res.params).not.toHaveProperty("geneid");
             expect(res.params.output).toEqual("json");

--- a/__test__/trapi_query_builder.test.js
+++ b/__test__/trapi_query_builder.test.js
@@ -23,7 +23,6 @@ describe("test trapi query builder class", () => {
             const builder = new qb(edge);
             const res = builder.getConfig();
             expect(res).toHaveProperty('url', 'https://google.com/query');
-            expect(res).toHaveProperty('timeout', 50000);
             expect(res.data.message.query_graph.nodes.n0.ids).toEqual(['123', '456']);
             expect(res.data.message.query_graph.nodes.n0.categories).toContain('biolink:Pathway');
             expect(res.data.message.query_graph.nodes.n1.categories).toContain('biolink:Gene');


### PR DESCRIPTION
Removing timeout check from Query Builder tests as the functionality has been moved to the APIQueryDispatcher in #53  