### PR TITLE
Fix package lock for smartapi-kg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "@biothings-explorer/call-apis",
       "version": "1.24.0",
       "license": "ISC",
       "dependencies": {
@@ -16,7 +17,7 @@
         "nunjucks": "^3.2.3"
       },
       "devDependencies": {
-        "@biothings-explorer/smartapi-kg": "^3.9.0",
+        "@biothings-explorer/smartapi-kg": "^4.0.0",
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
         "coveralls": "^3.1.0",
@@ -547,9 +548,9 @@
       }
     },
     "node_modules/@biothings-explorer/smartapi-kg": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-3.9.0.tgz",
-      "integrity": "sha512-PXjx2AAql6wf65ZM5E0OwsVfN1tjWsCtNxoSGo4dmchK+HBE1/kWhCAXxRICSAjTHkcGfoXviJFiZv30lWcpjQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-4.0.0.tgz",
+      "integrity": "sha512-cOX+D9uMShl0GqRuxMQQeryM2Ejx+BDmHU1/SP94I33fLUddp+Qs+Hax78PFlCiK/H9LCv0BU2u9iw/gUdgKmg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
@@ -9338,9 +9339,9 @@
       }
     },
     "@biothings-explorer/smartapi-kg": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-3.9.0.tgz",
-      "integrity": "sha512-PXjx2AAql6wf65ZM5E0OwsVfN1tjWsCtNxoSGo4dmchK+HBE1/kWhCAXxRICSAjTHkcGfoXviJFiZv30lWcpjQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@biothings-explorer/smartapi-kg/-/smartapi-kg-4.0.0.tgz",
+      "integrity": "sha512-cOX+D9uMShl0GqRuxMQQeryM2Ejx+BDmHU1/SP94I33fLUddp+Qs+Hax78PFlCiK/H9LCv0BU2u9iw/gUdgKmg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",


### PR DESCRIPTION
This updates the package-lock.json since smartapi-kg was updated to version 4.0.0. The previous package-lock was preventing the tests  from running as it was inconsistent with the package.json.