### PR TITLE
Update biomedical ID resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@biothings-explorer/api-response-transform": "^1.12.0",
         "axios": "^0.21.1",
-        "biomedical_id_resolver": "^3.10.0",
+        "biomedical_id_resolver": "^3.11.0",
         "debug": "^4.3.1",
         "husky": "^4.3.8",
         "nunjucks": "^3.2.3"
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/biomedical_id_resolver": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.10.0.tgz",
-      "integrity": "sha512-lDoH445DiIRkeu0KTureZNgF0EyAIRsqkzaBYuu8XgPalareTHqxwUCRcrjk5gRtel9TYuaNgK2UA/xQQ4sXlw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.11.0.tgz",
+      "integrity": "sha512-up14ykqbZTcf/9VUzICtxRHpVR7tzxgeZrr3FheKKVdM8cSzfBbku6wF1jifCRtQXGDJIZTjPAQRiGeK5lOnzw==",
       "dependencies": {
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
@@ -10284,9 +10284,9 @@
       }
     },
     "biomedical_id_resolver": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.10.0.tgz",
-      "integrity": "sha512-lDoH445DiIRkeu0KTureZNgF0EyAIRsqkzaBYuu8XgPalareTHqxwUCRcrjk5gRtel9TYuaNgK2UA/xQQ4sXlw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/biomedical_id_resolver/-/biomedical_id_resolver-3.11.0.tgz",
+      "integrity": "sha512-up14ykqbZTcf/9VUzICtxRHpVR7tzxgeZrr3FheKKVdM8cSzfBbku6wF1jifCRtQXGDJIZTjPAQRiGeK5lOnzw==",
       "requires": {
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@biothings-explorer/api-response-transform": "^1.12.0",
     "axios": "^0.21.1",
-    "biomedical_id_resolver": "^3.10.0",
+    "biomedical_id_resolver": "^3.11.0",
     "debug": "^4.3.1",
     "husky": "^4.3.8",
     "nunjucks": "^3.2.3"


### PR DESCRIPTION
The ``_annotate`` method in ``query.js`` is using ``resolver.resolveSRI`` which is only available in the newer version of biomedical id resolver, causing some tests to fail. Therefore, I have upgraded biomedical_id_resolver to version 3.11.0