### PR TITLE
Record cutoff

### DIFF
--- a/__test__/integration/integration.test.js
+++ b/__test__/integration/integration.test.js
@@ -14,7 +14,7 @@ describe("Integration test", () => {
         test("check response", async () => {
             const query = new q([edge]);
             const res = await query.query();
-            expect([...res.reduce((set, record) => set.add(record.recordHash), new Set())]).toHaveLength(27);
+            expect([...res.reduce((set, record) => set.add(record.recordHash), new Set())]).toHaveLength(28);
         })
     })
 

--- a/__test__/query.test.js
+++ b/__test__/query.test.js
@@ -68,25 +68,6 @@ describe("Test query class", () => {
             expect(res[1]).toEqual(success2.value[0]);
             expect(res[2]).toEqual(success1.value[0]);
         })
-
-        test("logs is correctly populated", () => {
-            const success1 = {
-                status: "fulfilled",
-                value: [{ id: 1 }]
-            }
-            const success2 = {
-                status: "fulfilled",
-                value: [{ id: 3 }]
-            }
-            const fail = {
-                status: "rejected",
-                reason: "bad request"
-            }
-            const caller = new q([]);
-            caller._merge([success1, success2, success1, fail, fail]);
-            expect(caller.logs).toHaveLength(1);
-            expect(caller.logs[0]).toHaveProperty("message", "call-apis: Total number of records returned for this query is 3")
-        })
     })
 
     describe("Test _groupOutputIDsBySemanticType function", () => {

--- a/src/query.js
+++ b/src/query.js
@@ -295,23 +295,23 @@ module.exports = class APIQueryDispatcher {
                     let server;
                     switch (process.env.INSTANCE_ENV ?? '') {
                         case 'dev':
-                            server = 'https://api.bte.ncats.io';
+                            server = 'api.bte.ncats.io';
                             break;
                         case 'ci':
-                            server = 'https://bte.ci.transltr.io';
+                            server = 'bte.ci.transltr.io';
                             break;
                         case 'test':
-                            server = 'https://bte.test.transltr.io';
+                            server = 'bte.test.transltr.io';
                             break;
                         default:
-                            server = `https://bte.transltr.io`;
+                            server = `bte.transltr.io`;
                     }
                     message.pop();
                     message.unshift([
                         `${server}: Attached query`,
                         global.queryInformation.jobID
-                            ? ` (ID: <${server}/v1/check_query_status/${global.queryInformation.jobID}|${global.queryInformation.jobID}>) `
-                            : ' (synchronous) ',
+                            ? ` (ID: <https://${server}/v1/check_query_status/${global.queryInformation.jobID}|${global.queryInformation.jobID}>)`
+                            : ' (synchronous)',
                         global.queryInformation.callback_url
                             ? ` (callback: ${global.queryInformation.callback_url}): `
                             : global.queryInformation.jobID ? ` (no callback provided): ` : `: `,

--- a/src/query.js
+++ b/src/query.js
@@ -29,8 +29,8 @@ module.exports = class APIQueryDispatcher {
         this.logs = [];
         this.options = options;
         this.totalRecords = 0;
-        this.maxRecords = parseInt(process.env.MAX_RECORDS_PER_EDGE) || 50000;
-        this.globalMaxRecords = parseInt(process.env.MAX_RECORDS_TOTAL) || 100000;
+        this.maxRecords = parseInt(process.env.MAX_RECORDS_PER_EDGE) || 30000;
+        this.globalMaxRecords = parseInt(process.env.MAX_RECORDS_TOTAL) || 60000;
         this.stoppedOnMax = false
         this.nextPageQueries = 0;
     }

--- a/src/query.js
+++ b/src/query.js
@@ -334,6 +334,9 @@ module.exports = class APIQueryDispatcher {
                 message.pop();
                 message.unshift([
                     `${server}: Attached query`,
+                    global.queryInformation.isCreativeMode
+                        ? ` (creative mode, template ${global.queryInformation.creativeTemplate}) `
+                        : ``,
                     global.queryInformation.jobID
                         ? ` (ID: <https://${server}/v1/check_query_status/${global.queryInformation.jobID}|${global.queryInformation.jobID}>)`
                         : ' (synchronous)',

--- a/src/query.js
+++ b/src/query.js
@@ -29,8 +29,8 @@ module.exports = class APIQueryDispatcher {
         this.logs = [];
         this.options = options;
         this.totalRecords = 0;
-        this.maxRecords = parseInt(process.env.MAX_RECORDS_PER_EDGE) || 30000;
-        this.globalMaxRecords = parseInt(process.env.MAX_RECORDS_TOTAL) || 60000;
+        this.maxRecords = parseInt(process.env.MAX_RECORDS_PER_EDGE) || 50000;
+        this.globalMaxRecords = parseInt(process.env.MAX_RECORDS_TOTAL) || 100000;
         this.stoppedOnMax = false
         this.nextPageQueries = 0;
     }


### PR DESCRIPTION
Stop subquerying for an edge after hitting a certain record cutoff threshold. At a second, higher threshold, stop query execution altogether. Optionally, log relevant information to a Slack Bot.

Related: 
biothings/BioThings_Explorer_TRAPI#547
biothings/bte_trapi_query_graph_handler#133